### PR TITLE
Adding strict request verification

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,9 +1,13 @@
 'use strict';
 function echo(event) {
-  return Promise.resolve({
-    messageText: event.message.text,
-    senderId: event.sender.id
-  });
+  if (typeof event.message !== 'undefined' && event.message !== null) {
+    return Promise.resolve({
+      messageText: event.message.text,
+      senderId: event.sender.id
+    });
+  } else {
+    return Promise.resolve({});
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
Facebook seems to like to send blank queries sometimes, so this little patch ensures that the system will only try to process those requests with a proper 'message' attached.
